### PR TITLE
add pseudo kana/kanji support

### DIFF
--- a/jaroomaji.dict.yaml
+++ b/jaroomaji.dict.yaml
@@ -13,5 +13,6 @@ import_tables:
   - jaroomaji.jmdict
   - jaroomaji.mozcemoji
   - jaroomaji.kanjidic2
+  - jaroomaji.kigou_extension
 # - jaroomaji.neologd  # TODO neologdから変換した辞書を作成する
 ...

--- a/jaroomaji.kigou_extension.dict.yaml
+++ b/jaroomaji.kigou_extension.dict.yaml
@@ -1,0 +1,47 @@
+# Rime dictionary
+# encoding: utf-8
+#
+# 古文書向けの仮名記号拡張
+#
+
+---
+name: jaroomaji.kigou_extension
+version: "1.0"
+sort: by_weight
+use_preset_vocabulary: false
+...
+
+#　踊り字
+々	do u	80000
+々	o na ji	80000
+々	o do ri ji	80000
+々	ku ri ka e shi	80000
+ヽ	ku ri ka e shi	80000
+ゝ	ku ri ka e shi	80000
+〻	ku ri ka e shi	80000
+〃	ku ri ka e shi	80000
+## 一の字点
+ゝ	ichi no ji ten n	80000
+ヽ	ichi no ji ten n	80000
+ゞ	ichi no ji ten n	80000
+ヾ	ichi no ji ten n	80000
+## 二の字点
+〻	ni no ji ten n	80000
+## ノノ点
+〃	no no ten n	80000
+## くの字点
+〳	ku no ji ten n	80000
+〴	ku no ji ten n	80000
+〵	ku no ji ten n	80000
+〱	ku no ji ten n	80000
+〲	ku no ji ten n	80000
+#　合略仮名
+ゟ	yo ri	80000
+ヿ	ko to	80000
+𬼂	na ri	80000
+〆	shi me	80000
+𪜈	to mo	80000
+𬼀	shi te	80000
+乄	shi me	80000
+# ほかの記号
+〼	ma su	80000


### PR DESCRIPTION
今回作成されたMicrosoft IME風のスキーマは、これまでの入力習慣に合致し、非常に使いやすいと感じます。
でも、このスキーマのなかの辞書は、ただ一種類の踊り字(ノマ点、々)しか入力できない。入力方法もノマを入力するのみだよね。古文書の翻刻を行う私にとっては、踊り字や合略仮名がなければ不便を感じますよね。それで、いま記号拡張の辞書を作成した。ほかの人にも役を立つかもしれないから、このPRをマージすればありがたいです。
---------------------------------------------------------------------------------------------------------
[外国人だから、もし誤りがあると、下記の英語内容を参照してください。]
[Because I'm a foreigner, please refer to English text if there is some wrong in my Japanese text.]
Your Microsoft IME-style schema is very user-friendly and aligns well with my previous input habits. Thanks for your masterpiece.
However, the dictionary within this schema can only input one type of iteration mark (noma ten, 々), and the method to input 々 is also limited to entering "no ma". Because I usually transcribes Japanese Komonjo (古文書), the absence of Pseudo Kana and Kanji poses a significant inconvenience. Therefore, I have created an extended dictionary of these characters. I believe this could be beneficial to others as well, so please merge this pull request.